### PR TITLE
feat: :sparkles: added support for LOC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ dirs = "5.0.0"
 graphql_client = { version = "0.12.0", features = ["reqwest-blocking"] }
 reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.95"
 term-table = "1.3.2"

--- a/src/get_detailed_view.rs
+++ b/src/get_detailed_view.rs
@@ -65,7 +65,7 @@ fn clean_terminal() {
 }
 
 // prints the ascii text to the terminal, colorful
-fn ascii_text(txt: String) {
+pub(crate) fn ascii_text(txt: String) {
     say(Options {
         text: txt,
         font: Fonts::FontTiny,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -29,7 +29,23 @@ pub fn cli_input() -> (String, String) {
             .long("author")
             .action(ArgAction::SetTrue)
         )
+        .arg(
+            Arg::new("LOC")
+            // .short("loc")
+            .long("loc")
+            .help("Shows line of code"),
+        )
         .get_matches();
+
+    let repo_url = match matches.get_one::<String>("LOC") {
+        None => "None",
+        Some(val) => val,
+    };
+
+    if repo_url != "None" {
+        crate::lines_of_codes::start_lines(repo_url.to_string());
+        std::process::exit(0);
+    }
 
     // for menu bar
     match matches.get_flag("o") {

--- a/src/lines_of_codes.rs
+++ b/src/lines_of_codes.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use reqwest::Url;
 use std::collections::HashMap;
-use term_table::{Table, row::Row, table_cell::TableCell};
+use term_table::{row::Row, table_cell::TableCell, Table};
 
 #[derive(Debug)]
 struct LocStruct {
@@ -39,18 +39,12 @@ fn find_lines(pair: (&str, &str)) -> Result<(HashMap<String, LocStruct>), Error>
             .get("linesOfCode")
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
-        let blanks = loc_data
-        .get("blanks")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0);
+        let blanks = loc_data.get("blanks").and_then(|v| v.as_u64()).unwrap_or(0);
         let comments = loc_data
-        .get("comments")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0);
-        let lines = loc_data
-        .get("lines")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0);;
+            .get("comments")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let lines = loc_data.get("lines").and_then(|v| v.as_u64()).unwrap_or(0);
 
         loc_map.insert(
             language.clone(),
@@ -65,11 +59,8 @@ fn find_lines(pair: (&str, &str)) -> Result<(HashMap<String, LocStruct>), Error>
         );
     }
 
-    
-
     Ok((loc_map))
 }
-
 
 fn create_loc_table(data: HashMap<String, LocStruct>, url: String) {
     let mut table = Table::new();
@@ -82,7 +73,6 @@ fn create_loc_table(data: HashMap<String, LocStruct>, url: String) {
         TableCell::new_with_alignment("Blanks", 3, term_table::table_cell::Alignment::Right),
         TableCell::new_with_alignment("Comments", 4, term_table::table_cell::Alignment::Right),
         TableCell::new_with_alignment("Lines Of Code", 5, term_table::table_cell::Alignment::Right),
-
     ]));
 
     for (_, loc_data) in data {
@@ -95,16 +85,19 @@ fn create_loc_table(data: HashMap<String, LocStruct>, url: String) {
         table.add_row(Row::new(vec![
             TableCell::new(lang),
             TableCell::new_with_alignment(file, 1, term_table::table_cell::Alignment::Right),
-        TableCell::new_with_alignment(lines, 2, term_table::table_cell::Alignment::Right),
-        TableCell::new_with_alignment(blanks, 3, term_table::table_cell::Alignment::Right),
-        TableCell::new_with_alignment(comments, 4, term_table::table_cell::Alignment::Right),
-        TableCell::new_with_alignment(lines_of_code, 5, term_table::table_cell::Alignment::Right),
+            TableCell::new_with_alignment(lines, 2, term_table::table_cell::Alignment::Right),
+            TableCell::new_with_alignment(blanks, 3, term_table::table_cell::Alignment::Right),
+            TableCell::new_with_alignment(comments, 4, term_table::table_cell::Alignment::Right),
+            TableCell::new_with_alignment(
+                lines_of_code,
+                5,
+                term_table::table_cell::Alignment::Right,
+            ),
         ]));
     }
     println!("The details of the repo: {url}\n");
     print!("{}", table.render());
 }
-
 
 pub fn start_lines(para_url: String) {
     let url: Vec<&str> = para_url
@@ -115,7 +108,7 @@ pub fn start_lines(para_url: String) {
         eprintln!("invalid url");
         std::process::exit(0);
     }
-    
+
     let username = url[url.len() - 2];
     let project = url[url.len() - 1];
     match find_lines((username, project)) {

--- a/src/lines_of_codes.rs
+++ b/src/lines_of_codes.rs
@@ -1,0 +1,131 @@
+use anyhow::Error;
+use reqwest::Url;
+use std::collections::HashMap;
+use term_table::{Table, row::Row, table_cell::TableCell};
+
+#[derive(Debug)]
+struct LocStruct {
+    language: String,
+    files: u64,
+    lines: u64,
+    blanks: u64,
+    comments: u64,
+    lines_of_code: u64,
+}
+
+fn find_lines(pair: (&str, &str)) -> Result<(HashMap<String, LocStruct>), Error> {
+    let (username, repo_name) = pair;
+    let mut loc_map: HashMap<String, LocStruct> = HashMap::new();
+    let input = format!("https://api.codetabs.com/v1/loc/?github={username}/{repo_name}");
+    let url = Url::parse(&input)?;
+    let response = reqwest::blocking::get(url).map_err(|err| reqwest::Error::from(err))?;
+
+    if response.status() != 200 {
+        eprintln!("Could not find the data associated with {username}/{repo_name}");
+        std::process::exit(0)
+    }
+
+    crate::get_detailed_view::ascii_text("LoC".to_string());
+    let body = response.text()?;
+    let data: Vec<HashMap<String, serde_json::Value>> = serde_json::from_str(&body)?;
+    for loc_data in data {
+        let language = loc_data
+            .get("language")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let files = loc_data.get("files").and_then(|v| v.as_u64()).unwrap_or(0);
+        let lines_of_code = loc_data
+            .get("linesOfCode")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let blanks = loc_data
+        .get("blanks")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+        let comments = loc_data
+        .get("comments")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+        let lines = loc_data
+        .get("lines")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);;
+
+        loc_map.insert(
+            language.clone(),
+            LocStruct {
+                language,
+                files,
+                lines_of_code,
+                blanks,
+                comments,
+                lines,
+            },
+        );
+    }
+
+    
+
+    Ok((loc_map))
+}
+
+
+fn create_loc_table(data: HashMap<String, LocStruct>, url: String) {
+    let mut table = Table::new();
+    table.max_column_width = 110;
+    table.style = term_table::TableStyle::thin();
+    table.add_row(Row::new(vec![
+        TableCell::new("Language"),
+        TableCell::new_with_alignment("Files", 1, term_table::table_cell::Alignment::Right),
+        TableCell::new_with_alignment("Lines", 2, term_table::table_cell::Alignment::Right),
+        TableCell::new_with_alignment("Blanks", 3, term_table::table_cell::Alignment::Right),
+        TableCell::new_with_alignment("Comments", 4, term_table::table_cell::Alignment::Right),
+        TableCell::new_with_alignment("Lines Of Code", 5, term_table::table_cell::Alignment::Right),
+
+    ]));
+
+    for (_, loc_data) in data {
+        let lang = loc_data.language;
+        let file = loc_data.files;
+        let lines_of_code = loc_data.lines_of_code;
+        let blanks = loc_data.blanks;
+        let comments = loc_data.comments;
+        let lines = loc_data.lines;
+        table.add_row(Row::new(vec![
+            TableCell::new(lang),
+            TableCell::new_with_alignment(file, 1, term_table::table_cell::Alignment::Right),
+        TableCell::new_with_alignment(lines, 2, term_table::table_cell::Alignment::Right),
+        TableCell::new_with_alignment(blanks, 3, term_table::table_cell::Alignment::Right),
+        TableCell::new_with_alignment(comments, 4, term_table::table_cell::Alignment::Right),
+        TableCell::new_with_alignment(lines_of_code, 5, term_table::table_cell::Alignment::Right),
+        ]));
+    }
+    println!("The details of the repo: {url}\n");
+    print!("{}", table.render());
+}
+
+
+pub fn start_lines(para_url: String) {
+    let url: Vec<&str> = para_url
+        .split(|c| c == '/')
+        .filter(|s| !s.is_empty())
+        .collect();
+    if url.len() < 1 {
+        eprintln!("invalid url");
+        std::process::exit(0);
+    }
+    
+    let username = url[url.len() - 2];
+    let project = url[url.len() - 1];
+    match find_lines((username, project)) {
+        Ok(data) => {
+            create_loc_table(data, para_url);
+            std::process::exit(0)
+        }
+        Err(_) => {
+            eprint!("Error");
+            std::process::exit(0);
+        }
+    };
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ mod input;
 mod github_graphql {
     pub mod detailed_view;
 }
+
+mod lines_of_codes;
 mod graph {
     pub mod graph_maker;
 }


### PR DESCRIPTION
this PR will close #36 
as now one can see all the lanugages used in a repo, with their lines of code, blanks, comments, lines. In a Tabular format
![Screenshot from 2023-04-09 20-26-10](https://user-images.githubusercontent.com/40994679/230783191-afc11c51-ad66-465d-925d-3667dcffb51a.png)
